### PR TITLE
fix: Add command spell validation and exceptions

### DIFF
--- a/src/main/kotlin/parser/exceptions/ParsingException.kt
+++ b/src/main/kotlin/parser/exceptions/ParsingException.kt
@@ -31,6 +31,8 @@ sealed class ParsingException(
         target: String,
     ) : ParsingException("Unknown servant target: $target")
 
+    class AllCommandSpellsAlreadyUsed() : ParsingException("All command spells already used")
+
     class IncompleteCommand : ParsingException("Incomplete command")
 
     class SkillCommandParseError(

--- a/src/main/kotlin/parser/exceptions/ParsingException.kt
+++ b/src/main/kotlin/parser/exceptions/ParsingException.kt
@@ -27,6 +27,10 @@ sealed class ParsingException(
 
     class MissingServantTarget() : ParsingException("Missing servant target")
 
+    class UnknownServantTarget(
+        target: String,
+    ) : ParsingException("Unknown servant target: $target")
+
     class IncompleteCommand : ParsingException("Incomplete command")
 
     class SkillCommandParseError(

--- a/src/main/kotlin/parser/exceptions/ParsingException.kt
+++ b/src/main/kotlin/parser/exceptions/ParsingException.kt
@@ -25,6 +25,8 @@ sealed class ParsingException(
         char: Char,
     ) : ParsingException("Unknown enemy target: $char")
 
+    class MissingServantTarget() : ParsingException("Missing servant target")
+
     class IncompleteCommand : ParsingException("Incomplete command")
 
     class SkillCommandParseError(

--- a/src/main/kotlin/parser/exceptions/ParsingException.kt
+++ b/src/main/kotlin/parser/exceptions/ParsingException.kt
@@ -25,13 +25,13 @@ sealed class ParsingException(
         char: Char,
     ) : ParsingException("Unknown enemy target: $char")
 
-    class MissingServantTarget() : ParsingException("Missing servant target")
+    class MissingServantTarget : ParsingException("Missing servant target")
 
     class UnknownServantTarget(
         target: String,
     ) : ParsingException("Unknown servant target: $target")
 
-    class AllCommandSpellsAlreadyUsed() : ParsingException("All command spells already used")
+    class AllCommandSpellsAlreadyUsed : ParsingException("All command spells already used")
 
     class IncompleteCommand : ParsingException("Incomplete command")
 

--- a/src/main/kotlin/parser/model/AutoSkillCommand.kt
+++ b/src/main/kotlin/parser/model/AutoSkillCommand.kt
@@ -131,6 +131,8 @@ class AutoSkillCommand private constructor(val stages: StageCommandList) {
                         val spell = SkillSource.CommandSpell.list.first { it.autoSkillCode == currentChar }
                         val (actionTarget, targetCodes) = getTarget(queue)
 
+                        actionTarget ?: throw ParsingException.MissingServantTarget()
+
                         val codes = "$currentChar$targetCodes"
 
                         AutoSkillAction.CommandSpell(

--- a/src/main/kotlin/parser/model/AutoSkillCommand.kt
+++ b/src/main/kotlin/parser/model/AutoSkillCommand.kt
@@ -69,9 +69,19 @@ class AutoSkillCommand private constructor(val stages: StageCommandList) {
             val queue: Deque<Char> = ArrayDeque(cmd.length)
             queue.addAll(cmd.asIterable())
 
+            var commandSpellUsed = 0
+
             return buildList {
                 while (queue.isNotEmpty()) {
                     val action = parseAction(queue = queue, wave = wave, turn = turn)
+
+                    // track the number of command spells used
+                    if (action is AutoSkillAction.CommandSpell) {
+                        commandSpellUsed++
+                        if (commandSpellUsed > 3) {
+                            throw ParsingException.AllCommandSpellsAlreadyUsed()
+                        }
+                    }
 
                     // merge NPs and cards before NPs
                     if (isNotEmpty() && action is AutoSkillAction.Atk) {

--- a/src/main/kotlin/parser/model/AutoSkillCommand.kt
+++ b/src/main/kotlin/parser/model/AutoSkillCommand.kt
@@ -131,7 +131,11 @@ class AutoSkillCommand private constructor(val stages: StageCommandList) {
                         val spell = SkillSource.CommandSpell.list.first { it.autoSkillCode == currentChar }
                         val (actionTarget, targetCodes) = getTarget(queue)
 
-                        actionTarget ?: throw ParsingException.MissingServantTarget()
+                        val target = actionTarget ?: throw ParsingException.MissingServantTarget()
+
+                        if (target !in SkillActionsTarget.fieldList) {
+                            throw ParsingException.UnknownServantTarget(targetCodes)
+                        }
 
                         val codes = "$currentChar$targetCodes"
 

--- a/src/main/kotlin/parser/model/AutoSkillCommand.kt
+++ b/src/main/kotlin/parser/model/AutoSkillCommand.kt
@@ -38,6 +38,11 @@ class AutoSkillCommand private constructor(val stages: StageCommandList) {
     fun commandTurnsAtStage(stage: Int): Int = stages.getOrNull(stage)?.flatten()?.size ?: 0
 
     private class CommandParser {
+
+        companion object {
+            private const val MAX_COMMAND_SPELLS = 3
+        }
+
         fun parseCommand(command: String): AutoSkillCommand {
             val trimmedCommand = command.trim()
             if (trimmedCommand.isEmpty()) return AutoSkillCommand(emptyList())
@@ -78,7 +83,7 @@ class AutoSkillCommand private constructor(val stages: StageCommandList) {
                     // track the number of command spells used
                     if (action is AutoSkillAction.CommandSpell) {
                         commandSpellUsed++
-                        if (commandSpellUsed > 3) {
+                        if (commandSpellUsed > MAX_COMMAND_SPELLS) {
                             throw ParsingException.AllCommandSpellsAlreadyUsed()
                         }
                     }

--- a/src/main/kotlin/parser/model/SkillActionsTarget.kt
+++ b/src/main/kotlin/parser/model/SkillActionsTarget.kt
@@ -123,5 +123,15 @@ sealed class SkillActionsTarget(
                 SpecialSkill.Transform,
             )
         }
+
+        val fieldList by lazy {
+            listOf(
+                A,
+                B,
+                C,
+                Left,
+                Right,
+            )
+        }
     }
 }

--- a/src/test/kotlin/commands/CommandSpellTest.kt
+++ b/src/test/kotlin/commands/CommandSpellTest.kt
@@ -82,17 +82,12 @@ class CommandSpellTest {
             AutoSkillCommand.parse(failCommand)
         }
     }
-
-    // Disabled: The parser currently does not throw an error for
-    // command spell strings that exceed the maximum number of commands.
-    // Once parser validation is implemented,
-    // this test should be enabled to ensure that exceeding the
-    // maximum number of commands fails as expected
-//    @Test
-//    fun `Max Command Spell is 3`(){
-//        assertFails {
-//            val failCommand = "o2p2o2p2"
-//            AutoSkillCommand.parse(failCommand)
-//        }
-//    }
+    
+    @Test
+    fun `Max Command Spell is 3`() {
+        assertFails {
+            val failCommand = "o2p2o2p2"
+            AutoSkillCommand.parse(failCommand)
+        }
+    }
 }

--- a/src/test/kotlin/commands/CommandSpellTest.kt
+++ b/src/test/kotlin/commands/CommandSpellTest.kt
@@ -7,6 +7,7 @@ import io.arthurkun.parser.model.SkillSource
 import org.junit.jupiter.api.BeforeAll
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFails
 import kotlin.test.assertIs
 
 class CommandSpellTest {
@@ -66,17 +67,13 @@ class CommandSpellTest {
         )
     }
 
-    // Disabled: The parser currently does not throw an error for
-    // incomplete command spell strings (e.g., "op2").
-    // Once parser validation is implemented,
-    // this test should be enabled to ensure incomplete commands fail as expected.
-//    @Test
-//    fun `Incomplete Command Spell should fail`() {
-//        assertFails {
-//            val failCommand = "op2"
-//            AutoSkillCommand.parse(failCommand)
-//        }
-//    }
+    @Test
+    fun `Incomplete Command Spell should fail`() {
+        assertFails {
+            val failCommand = "op2"
+            AutoSkillCommand.parse(failCommand)
+        }
+    }
 
     // Disabled: The parser currently does not throw an error for
     // command spell strings that exceed the maximum number of commands.

--- a/src/test/kotlin/commands/CommandSpellTest.kt
+++ b/src/test/kotlin/commands/CommandSpellTest.kt
@@ -75,6 +75,14 @@ class CommandSpellTest {
         }
     }
 
+    @Test
+    fun `Command Spell target should be field servant`() {
+        assertFails {
+            val failCommand = "p[Ch2A]"
+            AutoSkillCommand.parse(failCommand)
+        }
+    }
+
     // Disabled: The parser currently does not throw an error for
     // command spell strings that exceed the maximum number of commands.
     // Once parser validation is implemented,


### PR DESCRIPTION
This pull request introduces new validation logic for parsing auto-skill commands, ensuring stricter checks for command spell usage and target validation. It also includes updates to the test suite to cover these new validations. Below is a summary of the most important changes:

### Parsing Enhancements:
* Added new exception classes in `ParsingException` to handle specific parsing errors, including `MissingServantTarget`, `UnknownServantTarget`, and `AllCommandSpellsAlreadyUsed`. (`[src/main/kotlin/parser/exceptions/ParsingException.ktR28-R35](diffhunk://#diff-177343976d59cf71802d9c3f33446fa7f6314a105b2fd963990770bcacca47bcR28-R35)`)
* Introduced a `MAX_COMMAND_SPELLS` constant and logic in `AutoSkillCommand` to track and enforce a maximum of three command spells per command. Violations throw an `AllCommandSpellsAlreadyUsed` exception. (`[[1]](diffhunk://#diff-b89237020142dc232aca29ad6a65797fa8ef0b0b98271ae9283f32051b9bff6eR41-R45)`, `[[2]](diffhunk://#diff-b89237020142dc232aca29ad6a65797fa8ef0b0b98271ae9283f32051b9bff6eR77-R90)`)
* Added validation in `AutoSkillCommand` to ensure command spell targets are valid field servants. Throws `MissingServantTarget` or `UnknownServantTarget` exceptions for invalid or missing targets. (`[src/main/kotlin/parser/model/AutoSkillCommand.ktR149-R154](diffhunk://#diff-b89237020142dc232aca29ad6a65797fa8ef0b0b98271ae9283f32051b9bff6eR149-R154)`)

### Support for Target Validation:
* Added a `fieldList` property to `SkillActionsTarget` to define valid field servant targets. (`[src/main/kotlin/parser/model/SkillActionsTarget.ktR126-R135](diffhunk://#diff-5d44570a3d80e771e1423df8ccf8742f9455e4bfb05253af537ac07154af8bf4R126-R135)`)

### Test Suite Updates:
* Re-enabled and updated tests in `CommandSpellTest` to validate incomplete command spell strings, invalid targets, and exceeding the maximum number of command spells. (`[[1]](diffhunk://#diff-6d15874c88d047e6c2f94eeac114bcaecaf5e1f37fa23700d005822283ae1460R10)`, `[[2]](diffhunk://#diff-6d15874c88d047e6c2f94eeac114bcaecaf5e1f37fa23700d005822283ae1460L69-R92)`)